### PR TITLE
Add file dependencies (and other stuff)

### DIFF
--- a/Bakefile
+++ b/Bakefile
@@ -1,9 +1,13 @@
+# If OpenOS had the 'true' command built in, we wouldn't need to do the
+# shenanigans below:
+true = cat /dev/null
+
 default:
 	@echo "What do you expect me to do?"
 
 install:
 	@echo "Installing Bake..."
-	@mkdir /usr/bin/ 2>/dev/null
+	@mkdir /usr/bin/ 2>/dev/null || $(true)
 	@cp bake.lua /usr/bin/
 
 uninstall:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # Bake
-A partial `Make` reimplementation in Lua, built to automate building softwares on [OpenComputers](https://www.curseforge.com/minecraft/mc-mods/opencomputers)' OpenOS.
+A partial `GNU Make` reimplementation in Lua, built to automate building softwares on [OpenComputers](https://www.curseforge.com/minecraft/mc-mods/opencomputers)' OpenOS.
+The current version has been tested on Lua 5.2 and Lua 5.3.
+
+A good reference for `GNU Make` can be found [here](https://makefiletutorial.com/). This also describes additional features that may be added to Bake in the future.
 
 # Supported features
-- Macros
+- Macros/variables
+- Automatic variables (`$@`, `$?`, and `$^`)
 - Targets
+- File dependencies (and `.PHONY`)
+- Command silencing with `-s` and `@` prefix.
+- Error handling with `-i` and `-` prefix.
+
+# Differences compared to GNU Make
+- Variable assignment with `=` behaves like the 'simply expanded' `:=` operator. Recursive assignment with `=` and operators `?=` and `+=` are not yet implemented.
 
 # Installation
 To install this on OpenOS, just copy `bake.lua` to `/usr/bin/`.

--- a/bake.lua
+++ b/bake.lua
@@ -99,7 +99,7 @@ do
     ---@type integer
     local current_target = nil
     for line in bakefile_content:gmatch("[^\r\n]+") do
-        if not line:match("^#") then
+        if not line:match("^#") and line:match("%S") then
             local target_name, dependencies = line:match("^([^:]+):(.*)")
             if target_name then
                 current_target = #targets + 1
@@ -112,20 +112,19 @@ do
                 for dependency in dependencies:gmatch("[^ ]+") do
                     table.insert(targets[current_target].dependencies, dependency)
                 end
-            elseif current_target then
-                if line:match("^%s") then
-                    table.insert(targets[current_target].commands, line:match("^%s*(.*)"))
-                else
-                    current_target = nil
-                end
             else
                 -- TODO: Optimize pattern matching
                 local macro_name, macro_value = line:match("^([^=]+)=(.*)")
-                macro_name = macro_name:match("^%s*(.-)%s*$")
-                macro_value = macro_value:match("^%s*(.-)%s*$")
-
                 if macro_name then
+                    -- Trim whitespace
+                    macro_name = macro_name:match("^%s*(.-)%s*$")
+                    macro_value = macro_value:match("^%s*(.-)%s*$")
+
                     macros[macro_name] = resolve_macros(macro_value)
+                elseif current_target and line:match("^%s") then
+                    table.insert(targets[current_target].commands, line:match("^%s*(.*)"))
+                else
+                    current_target = nil
                 end
             end
         end

--- a/bake.lua
+++ b/bake.lua
@@ -2,8 +2,6 @@ local fs = require("filesystem")
 local sh = require("sh")
 local shell = require("shell")
 
-local xprint = require("xprint")
-
 --- Send command-line usage information to standard output.
 local function print_usage()
     print("Usage: bake [options] [target] ...")
@@ -34,8 +32,6 @@ do
         os.exit(2)
     end
     args.targets = raw_args
-
-    xprint({}, "args", args)
 end
 
 --- Check if a file exists
@@ -215,9 +211,6 @@ do
     if current_targets then
         add_targets()
     end
-
-    print("finished file scan")
-    xprint({}, "macros", macros, "targets", targets, "targets_metadata", targets_metadata)
 end
 
 --- Run a command

--- a/bake.lua
+++ b/bake.lua
@@ -6,8 +6,9 @@ local shell = require("shell")
 local function print_usage()
     print("Usage: bake [options] [target] ...")
     print("Options:")
-    print("  -h, --help             Print this message and exit.")
-    print("  -i, --ignore-errors    Ignore errors from recipes.")
+    print("  -h, --help               Print this message and exit.")
+    print("  -i, --ignore-errors      Ignore errors from recipes.")
+    print("  -s, --silent, --quiet    Don\'t echo recipes.")
 end
 
 ---@type table<string, any>
@@ -23,6 +24,12 @@ do
         args.ignore_errors = true
         raw_opts["i"] = nil
         raw_opts["ignore-errors"] = nil
+    end
+    if raw_opts["s"] or raw_opts["silent"] or raw_opts["quiet"] then
+        args.silent = true
+        raw_opts["s"] = nil
+        raw_opts["silent"] = nil
+        raw_opts["quiet"] = nil
     end
     if next(raw_opts) then
         local invalid_opt = next(raw_opts)
@@ -218,8 +225,10 @@ end
 ---@param command string
 local function run(target_name, command)
     command = resolve_macros(command)
+    local silent = args.silent
     local suppress_error = args.ignore_errors
     if command:sub(1,1) == "@" then
+        silent = true
         if command:sub(2,2) == "-" then
             suppress_error = true
             command = command:sub(3)
@@ -229,12 +238,13 @@ local function run(target_name, command)
     elseif command:sub(1,1) == "-" then
         suppress_error = true
         if command:sub(2,2) == "@" then
+            silent = true
             command = command:sub(3)
         else
             command = command:sub(2)
-            print(command)
         end
-    else
+    end
+    if not silent then
         print(command)
     end
     shell.execute(command)

--- a/bake.lua
+++ b/bake.lua
@@ -1,6 +1,8 @@
 local fs = require("filesystem")
 local shell = require("shell")
 
+local xprint = require("xprint")
+
 ---@type table<string, any>
 local args = {}
 do
@@ -43,7 +45,6 @@ do
 end
 
 ---@class MakeTarget
----@field name string
 ---@field update_time number
 ---@field dependencies table<integer, string>
 ---@field commands table<integer, string>
@@ -51,6 +52,20 @@ end
 local macros = {}
 ---@type table<string, MakeTarget>
 local targets = {}
+---@type table<integer, string>
+local targets_ordering = {}
+
+--- Metadata for targets (such as .PHONY). This is kept separate from the
+--- targets table to allow metadata to be defined independently (even for
+--- targets that don't exist).
+---@type table<string, table>
+local targets_metadata = setmetatable({}, {
+    __index = function(t, k)
+        local new_entry = {}
+        t[k] = new_entry
+        return new_entry
+    end
+})
 
 --- Resolve macros and commands
 ---@param text string
@@ -73,11 +88,14 @@ local function resolve_macros(text)
                     return nil
                 end,
                 info = function()
-                    return "echo '" .. args .. "'"
+                    return "@echo '" .. args .. "'"
                 end,
                 shell = function()
                     local stream = io.popen(args)
                     local result = stream:read("a")
+                    if result then
+                        result = result:gsub("\n", " ")
+                    end
                     stream:close()
                     return result
                 end,
@@ -100,24 +118,51 @@ local function resolve_macros(text)
 end
 
 do
-    ---@type integer
-    local current_target = nil
+    ---@type string
+    local current_targets = nil
+    ---@type string
+    local current_dependencies = nil
+    ---@type table<integer, string>
+    local last_target_commands = {}
+
+    --- Builds a new target using data stored in current_targets,
+    --- current_dependencies and last_target_commands
+    local function add_targets()
+        for target_name in current_targets:gmatch("%S+") do
+            if targets[target_name] then
+                io.stderr:write("bake: Found multiple definitions for target \'" .. target_name .. "\'.\n")
+                os.exit(1)
+            end
+            local new_target = {
+                update_time = -1,
+                dependencies = {},
+                commands = {}
+            }
+            targets[target_name] = new_target
+            targets_ordering[#targets_ordering + 1] = target_name
+
+            for dependency in current_dependencies:gmatch("%S+") do
+                table.insert(new_target.dependencies, dependency)
+            end
+            for i, command in ipairs(last_target_commands) do
+                new_target.commands[i] = command
+            end
+        end
+    end
+
+    -- Iterate each line in file (skipping any that begin with '#' character or
+    -- only whitespace). Check line for macros, target definitions, or commands
     for line in bakefile_content:gmatch("[^\r\n]+") do
         if not line:match("^#") and line:match("%S") then
-            local target_name, dependencies = line:match("^([^%s:]+):(.*)")
-            if target_name then
-                current_target = #targets + 1
-                targets[current_target] = {
-                    name = target_name,
-                    update_time = -1,
-                    dependencies = {},
-                    commands = {}
-                }
-                
-                for dependency in dependencies:gmatch("%S+") do
-                    table.insert(targets[current_target].dependencies, dependency)
+            if line:find("%s") ~= 1 then
+                if current_targets then
+                    add_targets()
+                    current_targets = nil
+                    current_dependencies = nil
+                    last_target_commands = {}
                 end
-            else
+                line = resolve_macros(line)
+
                 -- TODO: Optimize pattern matching
                 local macro_name, macro_value = line:match("^([^=]+)=(.*)")
                 if macro_name then
@@ -125,28 +170,32 @@ do
                     macro_name = macro_name:match("^%s*(.-)%s*$")
                     macro_value = macro_value:match("^%s*(.-)%s*$")
 
-                    macros[macro_name] = resolve_macros(macro_value)
-                elseif current_target and line:match("^%s") then
-                    table.insert(targets[current_target].commands, line:match("^%s*(.*)"))
+                    macros[macro_name] = macro_value
                 else
-                    current_target = nil
+                    local target_names, dependencies = line:match("^([^:]+):(.*)")
+
+                    if target_names then
+                        if target_names:match("^%.PHONY%s*$") then
+                            for target_name in dependencies:gmatch("%S+") do
+                                targets_metadata[target_name].phony = true
+                            end
+                        else
+                            current_targets = target_names
+                            current_dependencies = dependencies
+                        end
+                    end
                 end
+            elseif current_targets then
+                table.insert(last_target_commands, line:match("^%s*(.*)"))
             end
         end
     end
-end
-
---- Get a target by name
----@param name string
----@return MakeTarget
-local function get_target(name)
-    for _, target in pairs(targets) do
-        if target.name == name then
-            return target
-        end
+    if current_targets then
+        add_targets()
     end
-    io.stderr:write("bake: Target not found: " .. name .. "\n")
-    os.exit(1)
+
+    print("finished file scan")
+    xprint({}, "macros", macros, "targets", targets, "targets_metadata", targets_metadata)
 end
 
 --- Run a command
@@ -166,61 +215,92 @@ end
 ---@type table<MakeTarget, boolean>
 local traversed_targets = {}
 
---- Run a target
----@param target MakeTarget
+--- Run a target. Returns the file modification time if applicable, or math.huge
+--- to indicate that the target updated.
+---@param target_name string
 ---@param is_first boolean
 ---@return number
-local function run_target(target, is_first)
+local function run_target(target_name, is_first)
+    -- Find the target from the name (it may not be found, or it could be an
+    -- existing file)
+    local target = targets[target_name]
+    local target_path = shell.resolve(target_name)
+    if not target then
+        if not fs.exists(target_path) and not targets_metadata[target_name].phony then
+            io.stderr:write("bake: Target not found: " .. target_name .. "\n")
+            os.exit(1)
+        elseif is_first then
+            print("bake: Nothing to be done for \'" .. target_name .. "\'.")
+        end
+        if targets_metadata[target_name].phony then
+            return math.huge
+        else
+            return fs.lastModified(target_path)
+        end
+    end
+
     if traversed_targets[target] then
+        -- Cyclic dependency found
         return -1
     end
-    traversed_targets[target] = true
     if target.update_time ~= -1 then
         -- Do not run a given target more than once
         return target.update_time
     end
+    traversed_targets[target] = true
 
-    -- Find greatest modification timestamp of all dependency files
-    local depend_update_time = -1
-    for _,dependency in ipairs(target.dependencies) do
-        local update_time = run_target(get_target(dependency), false)
-        if update_time == -1 then
-            print("bake: Circular " .. target.name .. " <- " .. get_target(dependency).name .. " dependency dropped.")
-        end
-        depend_update_time = math.max(depend_update_time, update_time)
-    end
-
-    -- Finished dependencies for this target, remove the traversed_targets entry
-    -- so we don't mark it as a cycle in another target
-    traversed_targets[target] = nil
-
-    local target_path = shell.resolve(target.name)
-    if fs.exists(target_path) then
+    if fs.exists(target_path) and not targets_metadata[target_name].phony then
         target.update_time = fs.lastModified(target_path)
     else
         target.update_time = math.huge
     end
 
+    -- Create a space-separated list of each dependency, and another for just
+    -- the dependencies that changed for the target
+    local all_dependencies = ""
+    local updated_dependencies = ""
+    for _,dependency in ipairs(target.dependencies) do
+        local update_time = run_target(dependency, false)
+        if update_time == -1 then
+            print("bake: Circular " .. target_name .. " <- " .. dependency .. " dependency dropped.")
+        end
+        all_dependencies = all_dependencies .. dependency .. " "
+        if update_time == math.huge or target.update_time == math.huge or update_time > target.update_time then
+            updated_dependencies = updated_dependencies .. dependency .. " "
+        end
+    end
+    all_dependencies = all_dependencies:sub(1, -2)
+    updated_dependencies = updated_dependencies:sub(1, -2)
+
+    -- Finished dependencies for this target, remove the traversed_targets entry
+    -- so we don't mark it as a cycle in another target
+    traversed_targets[target] = nil
+
     -- Only run the target if no corresponding file found, or dependency updated
-    if target.update_time == math.huge or depend_update_time > target.update_time then
+    if target.update_time == math.huge or #updated_dependencies > 0 then
+        local automaticVars = {
+            ["@"] = target_name,
+            ["?"] = updated_dependencies,
+            ["^"] = all_dependencies
+        }
         for _,command in ipairs(target.commands) do
-            run(command)
+            run(command:gsub("%$([@?^])", automaticVars))
         end
         return math.huge
     elseif is_first then
-        print("bake: \'" .. target.name .. "\' is up to date.")
+        print("bake: \'" .. target_name .. "\' is up to date.")
     end
 
     return target.update_time
 end
 
-if #targets == 0 then
+if #targets_ordering == 0 then
     io.stderr:write("bake: No targets defined\n")
     os.exit(1)
 else
     if args.target then
-        run_target(get_target(args.target), true)
+        run_target(args.target, true)
     else
-        run_target(targets[1], true)
+        run_target(targets_ordering[1], true)
     end
 end

--- a/examples/basic/Bakefile
+++ b/examples/basic/Bakefile
@@ -1,0 +1,11 @@
+var1 = Hello
+ 
+default:
+	echo $(var1)
+	@echo "$(var1), world!"
+
+depend: dependency
+	@echo "This depends on target"
+
+dependency:
+	@echo "This is depended on by a target"

--- a/examples/errors/Bakefile
+++ b/examples/errors/Bakefile
@@ -1,0 +1,23 @@
+all: pass pass2 pass3
+
+# Runs fine, printing error codes to the output.
+pass:
+	-false
+	-ls /not_a_real_dir
+	-@false
+	@-false
+	touch pass
+
+pass2: fail
+	@echo "Running pass2"
+
+# Stops running targets in here.
+fail:
+	not_a_real_command
+	touch fail
+
+pass3:
+	@echo "Running pass3"
+
+clean:
+	-rm pass fail

--- a/examples/file-deps/Bakefile
+++ b/examples/file-deps/Bakefile
@@ -1,0 +1,47 @@
+# Dependency graph:
+#
+#    f <------.
+#   /|\       |
+#  / | \      |
+# f1 |  f3    |
+#  \ |  |\    |
+#   \|  | \   |
+#    f2 f4 f5 |
+#     \   /   |
+#      \ /    |
+#       f6----'
+#
+# If any target's dependencies update, the target should update too. Other
+# targets are left untouched.
+
+file: file1 file2 file3 file1
+	@echo "Update file"
+	@echo "." >> file
+
+file1: file2
+	@echo "Update file1"
+	@echo "." >> file1
+
+file2: file6
+	@echo "Update file2"
+	@echo "." >> file2
+
+file3: file4 file5
+	@echo "Update file3"
+	@echo "." >> file3
+
+file4:
+	@echo "Update file4"
+	@echo "." >> file4
+
+file5: file6
+	@echo "Update file5"
+	@echo "." >> file5
+
+file6: file
+	# file6 has a recursive dependency back to file (it should be ignored)
+	@echo "Update file6"
+	@echo "." >> file6
+
+clean:
+	rm file*

--- a/examples/macros/Bakefile
+++ b/examples/macros/Bakefile
@@ -1,0 +1,44 @@
+var1 = Hello
+
+# does stuff
+default:
+	# this comment appears in output
+	@# this does not
+	echo $(var1)
+	@echo "$(var1), world!"
+	# Tab does not show in output.
+	
+    # Neither does a blank line.
+
+	@echo "$(var2) message"
+	$(info this is called with info func)
+	echo $(shell ls /)
+
+# Declare some vars, and change one of the values (simply expanded behavior).
+var2 = test 123
+var3 = t1 t2	t3
+var2 = Another
+var4 = t1 t3
+
+# Target dependencies can be declared with a variable.
+t: $(var3)
+	@echo "running $@"
+	@echo "all newer prereqs = $?"
+	@echo "all prereqs = $^"
+	@echo "." >> t
+
+# Targets can also be declared with variable.
+$(var4): t2
+	@echo "running $@"
+	@echo "all newer prereqs = $?"
+	@echo "all prereqs = $^"
+	@echo "." >> $@
+
+# Disabled t2 target for test. The file must be created manually for 't' to run.
+#t2:
+
+# Declaring clean as .PHONY allows the target to always run regardless of any
+# file named 'clean'.
+.PHONY: clean
+clean:
+	rm t*

--- a/programs.cfg
+++ b/programs.cfg
@@ -1,0 +1,12 @@
+{
+    ["bake"] = {
+        files = {
+            ["master/bake.lua"] = "/bin",
+        },
+        name = "Bake",
+        description = "A partial implementation of Make written purely in Lua.",
+        note = "See https://github.com/atirut-w/bake for details.",
+        authors = "atirut-w",
+        repo = "tree/master",
+    },
+}


### PR DESCRIPTION
Hey @atirut-w, I'm currently using Bake for some OpenComputers projects I'm working on and I wanted to add some new features. At a high level I added:

* File dependency tracking and .phony
* Automatic variables (`$@`, `$?`, and `$^`)
* Improved error handling and some CLI flags
* A `programs.cfg` file to allow package installation with OpenPrograms Package Manager
* Example Bakefiles for reference/testing

I haven't tested the `programs.cfg` file yet since OPPM requires the file be on the `master` branch to be found. It may not work since the branch has the name `main` but I guess that's fine.

Also, I hope I'm correct in assuming we want GNU Make behavior for Bake? There's a few Make derivatives out there and I've been using the GNU version for testing.